### PR TITLE
feat: fix CI release branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "semantic-release": "^22.0.5",
-        "semantic-release-pypi": "^3.0.0"
+        "semantic-release-pypi": "^5.1.0"
     }
 }


### PR DESCRIPTION
I was not able to test this, but I checked the semantic-release-pypi changes between 3.0.0 and the latest version and it seems that this still works with node >=18. So bumping this should still work as expected.

- https://github.com/abichinger/semantic-release-pypi/compare/v3.0.0...v5.1.0
